### PR TITLE
feat(lambda-rs-logging): Adjust default log level for debug/release builds

### DIFF
--- a/crates/lambda-rs-logging/README.md
+++ b/crates/lambda-rs-logging/README.md
@@ -37,6 +37,11 @@ use logging; // renamed in Cargo.toml
 use lambda_rs_logging as logging;
 
 fn main() {
+  // Default global level:
+  // - Debug builds: DEBUG
+  // - Release builds: INFO
+  //
+  // Override at runtime with LAMBDA_LOG=trace|debug|info|warn|error|fatal
   logging::trace!("trace {}", 1);
   logging::debug!("debug {}", 2);
   logging::info!("info {}", 3);


### PR DESCRIPTION
## Summary

This PR updates the default log level behavior in `lambda-rs-logging` to use build-appropriate defaults:
- **Debug builds** (`cfg(debug_assertions)`): Default to `DEBUG` level
- **Release builds** (`cfg(not(debug_assertions))`): Default to `INFO` level

Previously, the global logger always initialized at `TRACE` level, which could produce excessive output in release builds. The runtime override via `LAMBDA_LOG` environment variable continues to work, and now gracefully handles the case where the global logger is already initialized.

## Related Issues

- Resolves #100 

## Changes

- Add `default_global_level()` function that returns `DEBUG` or `INFO` based on build type
- Consolidate `GLOBAL_LOGGER` to a single static instance
- Update `Logger::global()` and `Logger::init()` to use the shared static
- Update `env::init_global_from_env()` to use the default level and gracefully handle already-initialized loggers
- Add documentation about the default log level behavior in both lib.rs and README.md

## Type of Change

<!-- Mark the relevant option(s) with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (updates to docs, specs, tutorials, or comments)
- [x] Refactor (code change that neither fixes a bug nor adds a feature)
- [ ] Performance (change that improves performance)
- [ ] Test (adding or updating tests)
- [ ] Build/CI (changes to build process or CI configuration)

## Affected Crates

<!-- Mark the crate(s) affected by this change -->

- [ ] `lambda-rs`
- [ ] `lambda-rs-platform`
- [ ] `lambda-rs-args`
- [x] `lambda-rs-logging`
- [ ] Other:


## Checklist

<!-- Ensure the following before requesting review -->

- [x] Code follows the repository style guidelines (`cargo +nightly fmt --all`)
- [x] Code passes clippy (`cargo clippy --workspace --all-targets -- -D warnings`)
- [x] Tests pass (`cargo test --workspace`)
- [x] New code includes appropriate documentation
- [x] Public API changes are documented
- [ ] Breaking changes are noted in this PR description

## Testing

**Commands run:**

```bash
cargo build --workspace
cargo test --workspace
```

**Manual verification steps (if applicable):**

1. Run a debug build and verify log level defaults to DEBUG
2. Run a release build and verify log level defaults to INFO
3. Set `LAMBDA_LOG=trace` and verify the override works in both build types

## Screenshots/Recordings

<!-- For visual changes, include before/after screenshots or recordings -->

## Platform Testing

<!-- Mark platforms where changes were verified -->

- [x] macOS
- [ ] Windows
- [ ] Linux

## Additional Notes

The change to consolidate `GLOBAL_LOGGER` into a single static also fixes a subtle issue where `Logger::global()` and `Logger::init()` were using separate `OnceLock` instances, meaning `init()` would fail with `AlreadyInitialized` even if the logger accessed via `global()` was the default one. Now both functions share the same static.
